### PR TITLE
fix: report not valid browser names as error

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -25,6 +25,11 @@ from playwright.sync_api import Browser, BrowserContext, Page
 def pytest_generate_tests(metafunc: Any) -> None:
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
+        for browser in browsers:
+            if browser not in ["chromium", "firefox", "webkit"]:
+                raise ValueError(
+                    f"'{browser}' is not allowed. Only chromium, firefox, or webkit are valid browser names."
+                )
         metafunc.parametrize("browser_name", browsers, scope="session")
 
 

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -165,3 +165,15 @@ def test_headful(testdir: Any) -> None:
     )
     result = testdir.runpytest("--browser", "chromium", "--headful")
     result.assert_outcomes(passed=1)
+
+
+def test_invalid_browser_name(testdir: Any) -> None:
+    testdir.makepyfile(
+        """
+        def test_base_url(page):
+            pass
+    """
+    )
+    result = testdir.runpytest("--browser", "test123")
+    result.assert_outcomes(errors=1)
+    assert "'test123' is not allowed" in "\n".join(result.outlines)


### PR DESCRIPTION
Before this change it lead to an AttributeError exception.