### PR TITLE
docs(readme): add config for pytest.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pytest --browser firefox
 pytest --browser chromium --browser webkit
 ```
 
-N.B.: If you use an editor like VBCode, you can use the [pytest.ini](https://docs.pytest.org/en/stable/reference.html#ini-options-ref) file for passing additional command line parameters. You can create it in the project's pytest sub-folder:
+If you want to add the CLI arguments automatically without specifying them, you can use the [pytest.ini](https://docs.pytest.org/en/stable/reference.html#ini-options-ref) file:
 ```ini
 # content of pytest.ini
 [pytest]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ pytest --browser firefox
 pytest --browser chromium --browser webkit
 ```
 
+N.B.: If you use an editor like VBCode, you can use the [pytest.ini](https://docs.pytest.org/en/stable/reference.html#ini-options-ref) file for passing additional command line parameters. You can create it in the project's pytest sub-folder:
+```ini
+# content of pytest.ini
+[pytest]
+# Run firefox with UI
+addopts = --headful --browser firefox
+
+```
+
+
 ## Fixtures
 This plugin configures Playwright-specific [fixtures for pytest](https://docs.pytest.org/en/latest/fixture.html). To use these fixtures, use the fixture name as an argument to the test function.
 


### PR DESCRIPTION
Using the pytest.ini is an advantage if users want to have different command line parameters in their projects and run tests from the IDE. Added a hint on that feature.