### PR TITLE
fix(django): configure DJANGO_SETTINGS_MODULE in conftest.py and use in memory database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
     - name: Test
       if: ${{ matrix.os != 'ubuntu-latest' }}
       run: pytest --cov=pytest_playwright --cov-report xml
-      env:
-        DJANGO_SETTINGS_MODULE: tests.assets.django.settings
     - name: Test on Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: xvfb-run pytest --cov=pytest_playwright --cov-report xml
-      env:
-        DJANGO_SETTINGS_MODULE: tests.assets.django.settings

--- a/tests/assets/django/settings.py
+++ b/tests/assets/django/settings.py
@@ -64,7 +64,7 @@ WSGI_APPLICATION = "proj1.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "NAME": ":memory:",
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,3 +29,4 @@ elif sys.platform == "win32":
     playwright_browser_path = f"{user_profile}\\AppData\\Local\\ms-playwright"
 
 os.environ["PLAYWRIGHT_BROWSERS_PATH"] = playwright_browser_path
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.assets.django.settings")


### PR DESCRIPTION
Configuring **DJANGO_SETTINGS_MODULE** in conftest.py would allow testing without configuring environment variable on CI and locally.
Since the Django tests are not run using Django Test Runner, need to manually configure to use in memory database so that it will not create a test database on the disk. [Django Docs](https://docs.djangoproject.com/en/3.1/topics/testing/overview/#the-test-database)