### PR TITLE
Don't paramaterize test functions that don't use browser fixtures

### DIFF
--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -155,6 +155,29 @@ def test_only_browser(testdir: Any) -> None:
     result.assert_outcomes(passed=1, skipped=2)
 
 
+def test_parameterization(testdir: Any) -> None:
+    testdir.makepyfile(
+        """
+        def test_all_browsers(page):
+            pass
+
+        def test_without_browser():
+            pass
+    """
+    )
+    result = testdir.runpytest(
+        "--verbose",
+        "--browser",
+        "chromium",
+        "--browser",
+        "firefox",
+        "--browser",
+        "webkit",
+    )
+    result.assert_outcomes(passed=4)
+    assert "test_without_browser PASSED" in "\n".join(result.outlines)
+
+
 def test_headful(testdir: Any) -> None:
     testdir.makepyfile(
         """


### PR DESCRIPTION
Fix #27 by applying the skip rules in `pytest_runtest_setup` instead of in an `autouse` fixture. Add a test to confirm that tests without browser fixtures are not paramaterized.