### PR TITLE
chore: bump Playwright to 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     url="https://github.com/microsoft/playwright-pytest",
     packages=["pytest_playwright"],
     include_package_data=True,
-    install_requires=["playwright==1.9.0", "pytest", "pytest-base-url"],
+    install_requires=["playwright>=1.9.0", "pytest", "pytest-base-url"],
     entry_points={"pytest11": ["playwright = pytest_playwright.pytest_playwright"]},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     url="https://github.com/microsoft/playwright-pytest",
     packages=["pytest_playwright"],
     include_package_data=True,
-    install_requires=["playwright==1.8.0a1", "pytest", "pytest-base-url"],
+    install_requires=["playwright==1.9.0", "pytest", "pytest-base-url"],
     entry_points={"pytest11": ["playwright = pytest_playwright.pytest_playwright"]},
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Not sure if we want to follow the strategy of pinning the versions all the time as we do in playwright-test or using `>=`. Second is probably better now since we follow now SemVer.