### PR TITLE
add --trace-dir option to record traces

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -8,3 +8,4 @@ wheel==0.36.2
 flake8==3.9.2
 pre-commit==2.13.0
 Django==3.2.4
+python-slugify==5.0.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     url="https://github.com/microsoft/playwright-pytest",
     packages=["pytest_playwright"],
     include_package_data=True,
-    install_requires=["playwright>=1.10.0", "pytest", "pytest-base-url"],
+    install_requires=["playwright>=1.10.0", "pytest", "pytest-base-url", "python-slugify"],
     entry_points={"pytest11": ["playwright = pytest_playwright.pytest_playwright"]},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 import sys
+from typing import Any
 
 import pytest
 
@@ -380,3 +382,18 @@ def test_device_emulation(testdir: pytest.Testdir) -> None:
     )
     result = testdir.runpytest("--device", "iPhone 11 Pro")
     result.assert_outcomes(passed=1)
+
+
+def test_trace_dir(testdir: pytest.Testdir, tmpdir: Any) -> None:
+    pyfile = testdir.makepyfile(
+        """
+        def test_base_url(page):
+            pass
+    """
+    )
+    result = testdir.runpytest("--trace-dir", str(tmpdir))
+    result.assert_outcomes(passed=1)
+    # trace-dir option slugifes the test name to create a unique file path.
+    slugified_recording = (f"{testdir.tmpdir.basename}-{pyfile.purebasename}"
+                           "-py-test-base-url-chromium.zip").replace('_', '-')
+    assert Path(tmpdir / slugified_recording).is_file()


### PR DESCRIPTION
I wanted to be able to run the https://playwright.dev/python/docs/trace-viewer for every test case. So I added an option to specify a directory to place the traces into. 

So a pytest use can specify `pytest --trace-dir traces` and every test case that use's the `page` fixture will have a trace recorded for it.

Currently written to only expect one page fixture to be used per test case. Thus the trace-recording file name is only unique per test-case. 

Not sure if you are willing to accept this addition?

Cheers