### PR TITLE
chore: change browser_context_args back to session fixture

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -132,7 +132,7 @@ def _build_artifact_test_folder(
     return os.path.join(output_dir, slugify(request.node.nodeid), folder_or_file_name)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def browser_context_args(
     pytestconfig: Any,
     playwright: Playwright,

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -154,7 +154,7 @@ def test_browser_context_args(testdir: pytest.Testdir) -> None:
         """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture(scope="session")
         def browser_context_args():
             return {"user_agent": "foobar"}
     """
@@ -323,7 +323,7 @@ def test_browser_context_args_device(testdir: pytest.Testdir) -> None:
         """
         import pytest
 
-        @pytest.fixture()
+        @pytest.fixture(scope="session")
         def browser_context_args(browser_context_args, playwright):
             iphone_11 = playwright.devices['iPhone 11 Pro']
             return {**browser_context_args, **iphone_11}


### PR DESCRIPTION
It seems like the tests are still passing and I'm not sure why I did change it a few months ago. Seems to help a bunch of users.

Relates #73.