### PR TITLE
test: add test for launching persistent context with session scope

### DIFF
--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -368,7 +368,6 @@ def test_launch_persistent_context_session(testdir: pytest.Testdir) -> None:
     """
     )
     result = testdir.runpytest()
-    breakpoint()
     result.assert_outcomes(passed=1)
 
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-pytest/issues/73

The main reason that the examples in the docs did not reflect the example inside the test.