### PR TITLE
Fix / Prevent 'ERROR at teardown' error

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -261,6 +261,7 @@ def context(
 def page(context: BrowserContext, base_url: str) -> Generator[Page, None, None]:
     page = context.new_page()
     yield page
+    page.close()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
if you run long enough especially --video --tracing
You will get  ERROR at teardown of test_XXXX[YYY] error. Here is how you reproduce.

_main_test.py_
```
def test_css_class(page):
    page.goto("/")
    page.click("text=Class Attribute")
    page.click(".btn-primary")

def test_hidden_layers(page):
    page.goto("/")
    page.click("text=Hidden Layers")
    page.click(".btn-success")

def test_click(page):
    page.goto("/")
    page.click("text=Click")
    page.click("#badButton")
    page.click("#badButton")

def test_text_input(page):
    page.goto("/")
    page.click("text=Text Input")
    page.fill("#newButtonName", "Test Name")
    page.click('#updatingButton')
    assert page.inner_text('#updatingButton') == "Test Name"

def test_hidding_button(page):
    page.goto("/")
    page.click("text=Scrollbars")
    page.click('#hidingButton')

```

_pytest.ini_
```
[pytest]
addopts = --base-url http://www.uitestingplayground.com  --browser firefox --browser chromium --browser webkit --tracing retain-on-failure --video retain-on-failure 
```

run command:
```
while [ $(pytest > ./fail.log; echo $?) -eq 0 ]; do echo "passed, retry"; done
```

What you should see after 5-10 runs on any methods

```
main_test.py::test_css_class[firefox] PASSED
main_test.py::test_hidden_layers[firefox] PASSED
main_test.py::test_hidden_layers[firefox] ERROR
main_test.py::test_click[firefox] ERROR
main_test.py::test_text_input[firefox] ERROR
main_test.py::test_hidding_button[firefox] ERROR
main_test.py::test_css_class[chromium] PASSED
...
...

==================================== ERRORS ====================================
_______________ ERROR at teardown of test_hidden_layers[firefox] _______________

browser = <Browser type=<BrowserType name=firefox executable_path=/home/ubuntu/.cache/ms-playwright/firefox-1297/firefox/firefox> version=93.0>
browser_context_args = {'base_url': 'http://www.uitestingplayground.com', 'record_video_dir': '/tmp/playwright-pytest-6ngn5snc'}
pytestconfig = <_pytest.config.Config object at 0x7f477673cb90>
request = <SubRequest 'context' for <Function test_hidden_layers[firefox]>>

    @pytest.fixture
    def context(
        browser: Browser,
        browser_context_args: Dict,
        pytestconfig: Any,
        request: pytest.FixtureRequest,
    ) -> Generator[BrowserContext, None, None]:
        pages: List[Page] = []
        context = browser.new_context(**browser_context_args)
        context.on("page", lambda page: pages.append(page))
    
        tracing_option = pytestconfig.getoption("--tracing")
        capture_trace = tracing_option in ["on", "retain-on-failure"]
        if capture_trace:
            context.tracing.start(
                name=slugify(request.node.nodeid),
                screenshots=True,
                snapshots=True,
            )
    
        yield context
    
        if capture_trace:
            retain_trace = tracing_option == "on" or (
                request.node.rep_call.failed and tracing_option == "retain-on-failure"
            )
            if retain_trace:
                trace_path = _build_artifact_test_folder(pytestconfig, request, "trace.zip")
                context.tracing.stop(path=trace_path)
            else:
                context.tracing.stop()
    
        screenshot_option = pytestconfig.getoption("--screenshot")
        capture_screenshot = screenshot_option == "on" or (
            request.node.rep_call.failed and screenshot_option == "only-on-failure"
        )
        if capture_screenshot:
            for index, page in enumerate(pages):
                human_readable_status = (
                    "failed" if request.node.rep_call.failed else "finished"
                )
                screenshot_path = _build_artifact_test_folder(
                    pytestconfig, request, f"test-{human_readable_status}-{index+1}.png"
                )
                try:
                    page.screenshot(timeout=5000, path=screenshot_path)
                except Error:
                    pass
    
>       context.close()

```

### The work-around fix is using conftest.py to override the default pytest.fixture of `def page`

_conftest.py_
```
from typing import Generator
import pytest

from playwright.sync_api import (
    BrowserContext,
    Page
)

@pytest.fixture
def page(context: BrowserContext, base_url: str) -> Generator[Page, None, None]:
    page = context.new_page()
    yield page
    page.close()
```

### Perm Fix
Will be this pull request