### PR TITLE
Added check for if rep_call is missing

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -208,12 +208,9 @@ def context(
 
     yield context
 
-    try:
-        failed = request.node.rep_call.failed
-    except AttributeError:
-        # If requst.node is missing rep_call, then some error happened during execution
-        # that prevented teardown, but should still be counted as a failure
-        failed = True
+    # If requst.node is missing rep_call, then some error happened during execution
+    # that prevented teardown, but should still be counted as a failure
+    failed = request.node.rep_call.failed if hasattr(request.node, "rep_call") else True
 
     if capture_trace:
         retain_trace = tracing_option == "on" or (

--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -208,9 +208,16 @@ def context(
 
     yield context
 
+    rep_call = getattr(request.node, "rep_call", None)
+    if rep_call is None:
+        # If requst.node is missing rep_call, then some error happened during execution
+        # that prevented teardown, but should still be counted as a failure
+        failure = True
+    else:
+        failure = rep_call.failure
     if capture_trace:
         retain_trace = tracing_option == "on" or (
-            request.node.rep_call.failed and tracing_option == "retain-on-failure"
+            failure and tracing_option == "retain-on-failure"
         )
         if retain_trace:
             trace_path = _build_artifact_test_folder(pytestconfig, request, "trace.zip")
@@ -220,13 +227,11 @@ def context(
 
     screenshot_option = pytestconfig.getoption("--screenshot")
     capture_screenshot = screenshot_option == "on" or (
-        request.node.rep_call.failed and screenshot_option == "only-on-failure"
+        failure and screenshot_option == "only-on-failure"
     )
     if capture_screenshot:
         for index, page in enumerate(pages):
-            human_readable_status = (
-                "failed" if request.node.rep_call.failed else "finished"
-            )
+            human_readable_status = "failed" if failure else "finished"
             screenshot_path = _build_artifact_test_folder(
                 pytestconfig, request, f"test-{human_readable_status}-{index+1}.png"
             )
@@ -239,7 +244,7 @@ def context(
 
     video_option = pytestconfig.getoption("--video")
     preserve_video = video_option == "on" or (
-        video_option == "retain-on-failure" and request.node.rep_call.failed
+        failure and video_option == "retain-on-failure"
     )
     if preserve_video:
         for page in pages:

--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -208,13 +208,12 @@ def context(
 
     yield context
 
-    rep_call = getattr(request.node, "rep_call", None)
-    if rep_call is None:
+    try:
+        failure = request.node.rep_call.failue
+    except AttributeError:
         # If requst.node is missing rep_call, then some error happened during execution
         # that prevented teardown, but should still be counted as a failure
         failure = True
-    else:
-        failure = rep_call.failure
     if capture_trace:
         retain_trace = tracing_option == "on" or (
             failure and tracing_option == "retain-on-failure"

--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -209,14 +209,15 @@ def context(
     yield context
 
     try:
-        failure = request.node.rep_call.failue
+        failed = request.node.rep_call.failed
     except AttributeError:
         # If requst.node is missing rep_call, then some error happened during execution
         # that prevented teardown, but should still be counted as a failure
-        failure = True
+        failed = True
+
     if capture_trace:
         retain_trace = tracing_option == "on" or (
-            failure and tracing_option == "retain-on-failure"
+            failed and tracing_option == "retain-on-failure"
         )
         if retain_trace:
             trace_path = _build_artifact_test_folder(pytestconfig, request, "trace.zip")
@@ -226,11 +227,11 @@ def context(
 
     screenshot_option = pytestconfig.getoption("--screenshot")
     capture_screenshot = screenshot_option == "on" or (
-        failure and screenshot_option == "only-on-failure"
+        failed and screenshot_option == "only-on-failure"
     )
     if capture_screenshot:
         for index, page in enumerate(pages):
-            human_readable_status = "failed" if failure else "finished"
+            human_readable_status = "failed" if failed else "finished"
             screenshot_path = _build_artifact_test_folder(
                 pytestconfig, request, f"test-{human_readable_status}-{index+1}.png"
             )
@@ -243,7 +244,7 @@ def context(
 
     video_option = pytestconfig.getoption("--video")
     preserve_video = video_option == "on" or (
-        failure and video_option == "retain-on-failure"
+        failed and video_option == "retain-on-failure"
     )
     if preserve_video:
         for page in pages:

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -416,7 +416,6 @@ def test_device_emulation(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(reason="https://github.com/microsoft/playwright-pytest/pull/96")
 def test_rep_call_keyboard_interrupt(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(
         """


### PR DESCRIPTION
Added a simple check to see if `request.node` is missing the `rep_call` attribute, and assume the test failed if it is missing. This should hopefully fix #89