### PR TITLE
Ignore FileNotFoundError when cleaning up output_dir

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -40,7 +40,11 @@ artifacts_folder = tempfile.TemporaryDirectory(prefix="playwright-pytest-")
 def delete_output_dir(pytestconfig: Any) -> None:
     output_dir = pytestconfig.getoption("--output")
     if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
+        try:
+            shutil.rmtree(output_dir)
+        except FileNotFoundError:
+            # When running in parallel, another thread may have already deleted the files
+            pass
 
 
 def pytest_generate_tests(metafunc: Any) -> None:


### PR DESCRIPTION
When running tests in parallel with either pytest-parallel or pytest-xdist, all threads try to delete the output_dir immediately. One thread will have already deleted the files while the other threads are trying to delete files as well which raises an error. This just ignore that error so that tests can still be run