### PR TITLE
Add two new options to output folder, about deletion and timestamping in name

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -145,7 +145,7 @@ def _build_artifact_test_folder(
     output_dir = pytestconfig.getoption("--output")
     output_timestamped = pytestconfig.getoption("--output-timestamped")
     result_dir = slugify(request.node.nodeid)
-    if output_timestamped == "on":
+    if output_timestamped=="on":
         result_dir = "-".join([timestamp, slugify(request.node.nodeid)])
         
     return os.path.join(output_dir, result_dir, folder_or_file_name)

--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -40,7 +40,7 @@ artifacts_folder = tempfile.TemporaryDirectory(prefix="playwright-pytest-")
 def delete_output_dir(pytestconfig: Any) -> None:
     output_dir = pytestconfig.getoption("--output")
     output_deletion = pytestconfig.getoption("--output-deletion")
-    if os.path.exists(output_dir) and output_deletion=="on":
+    if os.path.exists(output_dir) and output_deletion == "on":
         try:
             shutil.rmtree(output_dir)
         except FileNotFoundError:
@@ -145,9 +145,9 @@ def _build_artifact_test_folder(
     output_dir = pytestconfig.getoption("--output")
     output_timestamped = pytestconfig.getoption("--output-timestamped")
     result_dir = slugify(request.node.nodeid)
-    if output_timestamped=="on":
+    if output_timestamped == "on":
         result_dir = "-".join([timestamp, slugify(request.node.nodeid)])
-        
+
     return os.path.join(output_dir, result_dir, folder_or_file_name)
 
 

--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -40,7 +40,6 @@ artifacts_folder = tempfile.TemporaryDirectory(prefix="playwright-pytest-")
 def delete_output_dir(pytestconfig: Any) -> None:
     output_dir = pytestconfig.getoption("--output")
     output_deletion = pytestconfig.getoption("--output-deletion")
-
     if os.path.exists(output_dir) and output_deletion=="on":
         try:
             shutil.rmtree(output_dir)
@@ -141,11 +140,10 @@ def _is_debugger_attached() -> bool:
 
 
 def _build_artifact_test_folder(
-    pytestconfig: Any, request: pytest.FixtureRequest, timestamp, folder_or_file_name: str
+    pytestconfig: Any, request: pytest.FixtureRequest, timestamp: str, folder_or_file_name: str
 ) -> str:
     output_dir = pytestconfig.getoption("--output")
     output_timestamped = pytestconfig.getoption("--output-timestamped")
-    
     result_dir = slugify(request.node.nodeid)
     if output_timestamped == "on":
         result_dir = "-".join([timestamp, slugify(request.node.nodeid)])


### PR DESCRIPTION
TO offer more possibilities to user, realted to my issue #108 , i propose this PR.

There is two new options:
  - "--output-deletion". Allow to avoid deletion of the output folder before running test. By default to "on" to keep previous comportment
  - "--output-timestamped". Allow to add timestamping in output folder name. If the previous options is deactivated, allow to keep all tests in the same folder, and running several time the same test (could not be done at the moment).

These new options aims to guarantee compatibility with some professional CI practice/use (so in my case).

Thank you.