### PR TITLE
Provide context_args fixture for custom browser.new_context() arguments

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -144,13 +144,19 @@ def _build_artifact_test_folder(
     return os.path.join(output_dir, slugify(request.node.nodeid), folder_or_file_name)
 
 
+@pytest.fixture
+def context_args() -> Dict:
+    """Overwrite this fixture to provide custom arguments to browser.new_context"""
+    return {}
+
+
 @pytest.fixture(scope="session")
 def browser_context_args(
     pytestconfig: Any,
     playwright: Playwright,
     device: Optional[str],
+    context_args: Dict
 ) -> Dict:
-    context_args = {}
     if device:
         context_args.update(playwright.devices[device])
     base_url = pytestconfig.getoption("--base-url")


### PR DESCRIPTION
Allows a user to pass whatever kwargs they want before playwright-pytest plugin creates a new browser context.

For this issue https://github.com/microsoft/playwright-pytest/issues/111

Avoids a user having to rewrite the entire 

```python
@pytest.fixture(scope="session")
def browser_context_args(
    pytestconfig: Any,
    playwright: Playwright,
    device: Optional[str],
) -> Dict:
    context_args = {}
    if device:
        context_args.update(playwright.devices[device])
    base_url = pytestconfig.getoption("--base-url")
    if base_url:
        context_args["base_url"] = base_url

    video_option = pytestconfig.getoption("--video")
    capture_video = video_option in ["on", "retain-on-failure"]
    if capture_video:
        context_args["record_video_dir"] = artifacts_folder.name

    # Where a user would have to inject context_args now
    context_args["http_credentials"] = {'username': 'bill', 'password': ''}

    return context_args

```

Instead they can customise browser_context launch args just by writing this own fixture:

```python
@pytest.fixture
def context_args() -> Dict:
    return {"http_credentials": {'username': 'bill', 'password': ''}}
```