### PR TITLE
test: fix slowmo test assertion

### DIFF
--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -42,12 +42,13 @@ def test_slowmo(testdir: pytest.Testdir) -> None:
         """
         from time import monotonic
         def test_slowmo(page):
-            start_time = monotonic()
             email = "test@test.com"
             page.set_content("<input type='text'/>")
+            start_time = monotonic()
             page.type("input", email)
             end_time = monotonic()
-            assert end_time - start_time >= len(email)
+            assert end_time - start_time >= 1
+            assert end_time - start_time < 2
     """
     )
     result = testdir.runpytest("--browser", "chromium", "--slowmo", "1000")


### PR DESCRIPTION
Playwright for Pytest does not pin the Playwright version, thats why when running the build bots, always the most recent stable version of Playwright gets used. In a recent update of Playwright, `page.type` got fixed, and does not take `N * SLOWMO` time per char anymore and does just take `SLOWMO`.

See https://github.com/microsoft/playwright/pull/18990/files#diff-0eca1ab51684690a8b36d9035b964865da546fafc48c6d663b9a4491e3453d97L207 which fixed this behavior upstream.

In the Pytest plugin we had the expectation that its `N * SLOWMO`, this patch brings it back to the actual assertion how it should be.