### PR TITLE
fix: have correct trace title

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -223,7 +223,7 @@ def context(
     capture_trace = tracing_option in ["on", "retain-on-failure"]
     if capture_trace:
         context.tracing.start(
-            name=slugify(request.node.nodeid),
+            title=slugify(request.node.nodeid),
             screenshots=True,
             snapshots=True,
             sources=True,


### PR DESCRIPTION
We want [title](https://playwright.dev/docs/api/class-tracing#tracing-start-option-title) instead of name.

Fixes https://github.com/microsoft/playwright-pytest/issues/156