### PR TITLE
fix: support long test names

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import shutil
 import os
 import sys
@@ -151,7 +152,17 @@ def _build_artifact_test_folder(
     pytestconfig: Any, request: pytest.FixtureRequest, folder_or_file_name: str
 ) -> str:
     output_dir = pytestconfig.getoption("--output")
-    return os.path.join(output_dir, slugify(request.node.nodeid), folder_or_file_name)
+    return os.path.join(
+        output_dir,
+        truncate_file_name(slugify(request.node.nodeid)),
+        truncate_file_name(folder_or_file_name),
+    )
+
+
+def truncate_file_name(file_name: str) -> str:
+    if len(file_name) < 256:
+        return file_name
+    return f"{file_name[:100]}-{hashlib.sha256(file_name.encode()).hexdigest()[:7]}-{file_name[-100:]}"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -653,6 +653,32 @@ def test_artifacts_retain_on_failure(testdir: pytest.Testdir) -> None:
     _assert_folder_tree(test_results_dir, expected)
 
 
+def test_should_work_with_test_names_which_exceeds_256_characters(
+    testdir: pytest.Testdir,
+) -> None:
+    long_test_name = "abcdefghijklmnopqrstuvwxyz" * 100
+    testdir.makepyfile(
+        f"""
+        def test_{long_test_name}(page):
+            pass
+    """
+    )
+    result = testdir.runpytest("--tracing", "on")
+    result.assert_outcomes(passed=1, failed=0)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    expected = [
+        {
+            "name": "test-should-work-with-test-names-which-exceeds-256-characters-py-test-abcdefghijklmnopqrstuvwxyzabcd-23f2441-nopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz-chromium/",
+            "children": [
+                {
+                    "name": "trace.zip",
+                },
+            ],
+        },
+    ]
+    _assert_folder_tree(test_results_dir, expected)
+
+
 def _assert_folder_tree(root: str, expected_tree: List[Any]) -> None:
     assert len(os.listdir(root)) == len(expected_tree)
     for file in expected_tree:


### PR DESCRIPTION
So turns out the bug reported in https://github.com/microsoft/playwright-pytest/issues/164 was already fixed in https://github.com/microsoft/playwright-pytest/pull/157 it was just not released yet.

This PR fixes a different bug, which is similar tho, it fixes the issue if test names were too long, the `test-results/<sub-dir>` was too long.