### PR TITLE
chore: drop Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ignore =
     E302
 [mypy]
 ignore_missing_imports = True
-python_version = 3.7
+python_version = 3.8
 warn_unused_ignores = False
 warn_redundant_casts = True
 warn_unused_configs = True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
     entry_points={"pytest11": ["playwright = pytest_playwright.pytest_playwright"]},
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -32,7 +31,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Framework :: Pytest",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     use_scm_version={
         "version_scheme": "post-release",
         "write_to": "pytest_playwright/_repo_version.py",


### PR DESCRIPTION
As per https://github.com/microsoft/playwright-python/commit/062059604022201273772d4ad312fc8e62ede5ea