### PR TITLE
chore(conda): adjust minimal required playwright version

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - pip
   run:
     - python >=3.8
-    - playwright >=v1.33.0
+    - playwright >=1.37.0
     - pytest >=6.2.4,<8.0.0
     - pytest-base-url >=1.0.0,<3.0.0
     - python-slugify >=6.0.0,<9.0.0


### PR DESCRIPTION
This is how we stumbled on the v prefix issue. 

PIP is fine:

https://github.com/microsoft/playwright-pytest/blob/7fba23af6404b41998de2653b60c1f1b30199052/setup.py#L18