### PR TITLE
fix: mark.browser_context_args should clear for the next test

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -232,6 +232,7 @@ def context(
 ) -> Generator[BrowserContext, None, None]:
     pages: List[Page] = []
 
+    browser_context_args = browser_context_args.copy()
     context_args_marker = next(request.node.iter_markers("browser_context_args"), None)
     additional_context_args = context_args_marker.kwargs if context_args_marker else {}
     browser_context_args.update(additional_context_args)

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -193,6 +193,31 @@ def test_user_defined_browser_context_args(testdir: pytest.Testdir) -> None:
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
 
+def test_user_defined_browser_context_args_clear_again(testdir: pytest.Testdir) -> None:
+    testdir.makeconftest(
+        """
+        import pytest
+
+        @pytest.fixture(scope="session")
+        def browser_context_args():
+            return {"user_agent": "foobar"}
+    """
+    )
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.browser_context_args(user_agent="overwritten")
+        def test_browser_context_args(page):
+            assert page.evaluate("window.navigator.userAgent") == "overwritten"
+
+        def test_browser_context_args2(page):
+            assert page.evaluate("window.navigator.userAgent") == "foobar"
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=2)
+
 
 def test_chromium(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-pytest/issues/188