### PR TITLE
devops: migrate publishing to ESRP

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,0 +1,60 @@
+pr: none
+
+trigger:
+  tags:
+    include:
+    - '*'
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: DevDivPlaywrightAzurePipelinesUbuntu2204
+      os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: DevDivPlaywrightAzurePipelinesWindows2022
+        # The image must be windows-based due to restrictions of the SDL tools. See: https://aka.ms/AAo6v8e
+        # In the case of a windows build, this can be the same as the above pool image.
+        os: windows
+    stages:
+    - stage: Stage
+      jobs:
+      - job: HostJob
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.8'
+          displayName: 'Use Python'
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -r local-requirements.txt
+            python setup.py sdist bdist_wheel
+          displayName: 'Install & Build'
+        - task: EsrpRelease@7
+          inputs:
+            connectedservicename: 'Playwright-ESRP-Azure'
+            keyvaultname: 'pw-publishing-secrets'
+            authcertname: 'ESRP-Release-Auth'
+            signcertname: 'ESRP-Release-Sign'
+            clientid: '13434a40-7de4-4c23-81a3-d843dc81c2c5'
+            intent: 'PackageDistribution'
+            contenttype: 'PyPi'
+            # Keeping it commented out as a workaround for:
+            # https://portal.microsofticm.com/imp/v3/incidents/incident/499972482/summary
+            # contentsource: 'folder'
+            folderlocation: './dist/'
+            waitforreleasecompletion: true
+            owners: 'maxschmitt@microsoft.com'
+            approvers: 'maxschmitt@microsoft.com'
+            serviceendpointurl: 'https://api.esrp.microsoft.com'
+            mainpublisher: 'Playwright'
+            domaintenantid: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+          displayName: 'ESRP Release to PIP'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,26 +6,6 @@ on:
   release:
     types: [published]
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r local-requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
   deploy-conda:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is basically a copy of the playwright-python pipeline.

https://github.com/microsoft/playwright-internal/issues/203