### PR TITLE
feat:Add marker (tracing, screenshot, video)

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -102,6 +102,18 @@ def pytest_configure(config: Any) -> None:
         "markers",
         "browser_context_args(**kwargs): provide additional arguments to browser.new_context()",
     )
+    config.addinivalue_line(
+        "markers",
+        "tracing(flag): mark test case opening tracing. default:on",
+    )
+    config.addinivalue_line(
+        "markers",
+        "screenshot(flag): mark use case opening screenshot. default:on",
+    )
+    config.addinivalue_line(
+        "markers",
+        "video(flag): mark the use case to start recording. default:on",
+    )
 
 
 # Making test result information available in fixtures
@@ -318,11 +330,17 @@ def new_context(
     _artifacts_recorder: "ArtifactsRecorder",
     request: pytest.FixtureRequest,
 ) -> Generator[CreateContextCallback, None, None]:
+    contexts: List[BrowserContext] = []
     browser_context_args = browser_context_args.copy()
     context_args_marker = next(request.node.iter_markers("browser_context_args"), None)
     additional_context_args = context_args_marker.kwargs if context_args_marker else {}
     browser_context_args.update(additional_context_args)
-    contexts: List[BrowserContext] = []
+    if "record_video_dir" not in browser_context_args.keys():
+        video_mark = next(request.node.iter_markers("video"), None)
+        if (video_mark and len(video_mark.args) > 0 \
+                and video_mark.args[0] in ["on", "retain-on-failure"]):
+            browser_context_args.update(
+                {"record_video_dir": _artifacts_recorder._pw_artifacts_folder.name})
 
     def _new_context(**kwargs: Any) -> BrowserContext:
         context = browser.new_context(**browser_context_args, **kwargs)
@@ -473,13 +491,24 @@ class ArtifactsRecorder:
         self._all_pages: List[Page] = []
         self._screenshots: List[str] = []
         self._traces: List[str] = []
-        self._tracing_option = pytestconfig.getoption("--tracing")
+        self._tracing_option = self._get_trace_mark("tracing")
+        self._screenshot_option = self._get_trace_mark("screenshot")
+        self._video_option = self._get_trace_mark("video")
         self._capture_trace = self._tracing_option in ["on", "retain-on-failure"]
 
+    def _get_trace_mark(self, flag: Literal["tracing", "screenshot", "video"]):
+        _option = self._pytestconfig.getoption(f"--{flag}")
+        _mark = next(self._request.node.iter_markers(flag), False)
+        if _mark:
+            if len(_mark.args) == 0:
+                _option = "on"
+            else:
+                _option = _mark.args[0]
+        return _option
+
     def did_finish_test(self, failed: bool) -> None:
-        screenshot_option = self._pytestconfig.getoption("--screenshot")
-        capture_screenshot = screenshot_option == "on" or (
-            failed and screenshot_option == "only-on-failure"
+        capture_screenshot = self._screenshot_option == "on" or (
+                failed and self._screenshot_option == "only-on-failure"
         )
         if capture_screenshot:
             for index, screenshot in enumerate(self._screenshots):
@@ -511,7 +540,7 @@ class ArtifactsRecorder:
             for trace in self._traces:
                 os.remove(trace)
 
-        video_option = self._pytestconfig.getoption("--video")
+        video_option = self._video_option
         preserve_video = video_option == "on" or (
             failed and video_option == "retain-on-failure"
         )
@@ -561,7 +590,7 @@ class ArtifactsRecorder:
         else:
             context.tracing.stop()
 
-        if self._pytestconfig.getoption("--screenshot") in ["on", "only-on-failure"]:
+        if self._screenshot_option in ["on", "only-on-failure"]:
             for page in context.pages:
                 try:
                     screenshot_path = (

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -910,3 +910,124 @@ def test_new_context_allow_passing_args(
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_artifacts_should_store_everything_if_mark_is_on(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.mark.tracing("on")
+        @pytest.mark.screenshot
+        @pytest.mark.video
+        def test_passing(page):
+            assert 2 == page.evaluate("1 + 1")
+        
+        @pytest.mark.tracing
+        @pytest.mark.screenshot("on")
+        @pytest.mark.video("on")
+        def test_failing(page):
+            raise Exception("Failed")
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    _assert_folder_structure(
+        test_results_dir,
+        """
+- test-artifacts-should-store-everything-if-mark-is-on-py-test-failing-chromium:
+  - test-failed-1.png
+  - trace.zip
+- test-artifacts-should-store-everything-if-mark-is-on-py-test-passing-chromium:
+  - test-finished-1.png
+  - trace.zip
+""",
+    )
+
+
+def test_artifacts_should_store_everything_if_mark_is_off(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.tracing("off")
+        @pytest.mark.screenshot("off")
+        @pytest.mark.video("off")
+        def test_passing(page):
+            assert 2 == page.evaluate("1 + 1")
+
+        @pytest.mark.tracing("off")
+        @pytest.mark.screenshot("off")
+        @pytest.mark.video("off")
+        def test_failing(page):
+            raise Exception("Failed")
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    _assert_folder_structure(
+        test_results_dir, "",
+    )
+
+
+def test_artifacts_should_store_everything_if_mark_is_on_failure(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.tracing("retain_on_failure")
+        @pytest.mark.screenshot("only-on-failure")
+        @pytest.mark.video("retain_on_failure")
+        def test_passing(page):
+            assert 2 == page.evaluate("1 + 1")
+
+        @pytest.mark.tracing("retain-on-failure")
+        @pytest.mark.screenshot("only-on-failure")
+        @pytest.mark.video("retain-on-failure")
+        def test_failing(page):
+            raise Exception("Failed")
+    """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    _assert_folder_structure(
+        test_results_dir, """
+- test-artifacts-should-store-everything-if-mark-is-on-failure-py-test-failing-chromium:
+  - test-failed-1.png
+  - trace.zip
+""",
+    )
+
+
+def test_artifacts_should_store_everything_mark_and_option_all_exist(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+
+        # @pytest.mark.tracing("retain_on_failure")
+        # @pytest.mark.screenshot("only-on-failure")
+        # @pytest.mark.video("retain_on_failure")
+        # def test_passing(page):
+        #     assert 2 == page.evaluate("1 + 1")
+
+        @pytest.mark.tracing("retain-on-failure")
+        @pytest.mark.screenshot("only-on-failure")
+        @pytest.mark.video("retain-on-failure")
+        def test_failing(page):
+            raise Exception("Failed")
+    """
+    )
+    result = testdir.runpytest("--screenshot", "on", "--video", "on", "--tracing", "on")
+    result.assert_outcomes(passed=1, failed=1)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    _assert_folder_structure(
+        test_results_dir, """
+- test-artifacts-should-store-everything-if-mark-is-on-failure-py-test-failing-chromium:
+  - test-failed-1.png
+  - trace.zip
+  - video.webm
+""",
+    )


### PR DESCRIPTION
During testing, tracing, screenshot, video for all use cases at the same time takes up a lot of disk space. Especially trace.zip
`test_artifacts_should_store_everything_mark_and_option_all_exist`.Execution of this test case through pytest failed, but successful through python scripts