### PR TITLE
feature:Add pytest mark (tracing, video, screenshot)

### DIFF
--- a/pytest_playwright/pytest_playwright.py
+++ b/pytest_playwright/pytest_playwright.py
@@ -337,8 +337,9 @@ def new_context(
     browser_context_args.update(additional_context_args)
     if "record_video_dir" not in browser_context_args.keys():
         video_mark = next(request.node.iter_markers("video"), None)
-        if (video_mark and len(video_mark.args) > 0 \
-                and video_mark.args[0] in ["on", "retain-on-failure"]):
+        if video_mark and (
+                not video_mark.args or video_mark.args[0] in ["on", "retain-on-failure"]
+        ):
             browser_context_args.update(
                 {"record_video_dir": _artifacts_recorder._pw_artifacts_folder.name})
 

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -910,3 +910,41 @@ def test_new_context_allow_passing_args(
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_mark_by_trace_on(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        
+        @pytest.mark.tracing("on")
+        @pytest.mark.screenshot("on")
+        @pytest.mark.video("on")
+        def test_success(page):
+            assert 2 == page.evaluate("1 + 1")
+        
+        @pytest.mark.tracing("on")
+        @pytest.mark.screenshot("on")
+        @pytest.mark.video("on")
+        def test_fail(page):
+            raise Exception("Failed")
+        """
+    )
+    # result = testdir.runpytest( "--video", "on")
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    test_results_dir = os.path.join(testdir.tmpdir, "test-results")
+    top = os.walk(test_results_dir)
+    _assert_folder_structure(
+        test_results_dir,
+        """
+- test-mark-by-trace-on-py-test-fail-chromium:
+  - test-failed-1.png
+  - trace.zip
+  - video.webm
+- test-mark-by-trace-on-py-test-success-chromium:
+  - test-finished-1.png
+  - trace.zip
+  - video.webm
+"""
+    )

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -925,7 +925,7 @@ def test_artifacts_should_store_everything_if_mark_is_on(testdir: pytest.Testdir
         
         @pytest.mark.tracing
         @pytest.mark.screenshot("on")
-        @pytest.mark.video("on")
+        @pytest.mark.video
         def test_failing(page):
             raise Exception("Failed")
     """
@@ -939,9 +939,11 @@ def test_artifacts_should_store_everything_if_mark_is_on(testdir: pytest.Testdir
 - test-artifacts-should-store-everything-if-mark-is-on-py-test-failing-chromium:
   - test-failed-1.png
   - trace.zip
+  - video.webm
 - test-artifacts-should-store-everything-if-mark-is-on-py-test-passing-chromium:
   - test-finished-1.png
   - trace.zip
+  - video.webm
 """,
     )
 
@@ -968,7 +970,8 @@ def test_artifacts_should_store_everything_if_mark_is_off(testdir: pytest.Testdi
     result.assert_outcomes(passed=1, failed=1)
     test_results_dir = os.path.join(testdir.tmpdir, "test-results")
     _assert_folder_structure(
-        test_results_dir, "",
+        test_results_dir,
+        "",
     )
 
 
@@ -998,6 +1001,7 @@ def test_artifacts_should_store_everything_if_mark_is_on_failure(testdir: pytest
 - test-artifacts-should-store-everything-if-mark-is-on-failure-py-test-failing-chromium:
   - test-failed-1.png
   - trace.zip
+  - video.webm
 """,
     )
 
@@ -1007,11 +1011,11 @@ def test_artifacts_should_store_everything_mark_and_option_all_exist(testdir: py
         """
         import pytest
 
-        # @pytest.mark.tracing("retain_on_failure")
-        # @pytest.mark.screenshot("only-on-failure")
-        # @pytest.mark.video("retain_on_failure")
-        # def test_passing(page):
-        #     assert 2 == page.evaluate("1 + 1")
+        @pytest.mark.tracing("retain_on_failure")
+        @pytest.mark.screenshot("only-on-failure")
+        @pytest.mark.video("retain_on_failure")
+        def test_passing(page):
+            assert 2 == page.evaluate("1 + 1")
 
         @pytest.mark.tracing("retain-on-failure")
         @pytest.mark.screenshot("only-on-failure")
@@ -1025,7 +1029,7 @@ def test_artifacts_should_store_everything_mark_and_option_all_exist(testdir: py
     test_results_dir = os.path.join(testdir.tmpdir, "test-results")
     _assert_folder_structure(
         test_results_dir, """
-- test-artifacts-should-store-everything-if-mark-is-on-failure-py-test-failing-chromium:
+- test-artifacts-should-store-everything-mark-and-option-all-exist-py-test-failing-chromium:
   - test-failed-1.png
   - trace.zip
   - video.webm


### PR DESCRIPTION
Adding marks (tracing, video, screenshot) to all use cases takes up huge disk space, especially trace.zip. Add marks to record some use cases 