### PR TITLE
chore: add py.typed file

### DIFF
--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -775,8 +775,9 @@ def test_artifact_collection_should_work_for_manually_created_contexts_keep_open
     testdir.makepyfile(
         """
         import pytest
+        from pytest_playwright.pytest_playwright import CreateContextCallback
 
-        def test_artifact_collection(browser, page, new_context):
+        def test_artifact_collection(browser, page, new_context: CreateContextCallback):
             page.goto("data:text/html,<div>hello</div>")
 
             other_context = new_context()


### PR DESCRIPTION
Added a `py.typed` file to tell `mypy` (a Python linter) that we are a typed package.

Before we didn't treat https://github.com/microsoft/playwright-pytest/blob/695c3ead82a14874ca10abd2550c1add1f1ae727/pytest_playwright/pytest_playwright.py#L271 as part of our public API - but turns our our customers wants to have a typed `new_context` function which is reasonable.

Is the name `CreateContextCallback` appropriate? We are still under `0.X` releases - so we could rename in theory.

Fixes https://github.com/microsoft/playwright-pytest/issues/244