### PR TITLE
fix(conda): specify that 'playwright' is from 'microsoft' channel

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,3 +1,7 @@
+channels:
+  - microsoft
+  - conda-forge
+
 package:
   name: "pytest-playwright"
   version: "{{ environ.get('GIT_DESCRIBE_TAG') | replace('v', '') }}"
@@ -17,7 +21,7 @@ requirements:
     - pip
   run:
     - python >=3.8
-    - playwright >=1.37.0
+    - microsoft::playwright >=1.37.0
     - pytest >=6.2.4,<9.0.0
     - pytest-base-url >=1.0.0,<3.0.0
     - python-slugify >=6.0.0,<9.0.0


### PR DESCRIPTION
Since a few months there is also a `playwright` package on `conda-forge` which is a different conda channel compared to the one we publish. Lets specify explicitly that we want `playwright` from the `microsoft` channel.

Fixes https://github.com/microsoft/playwright-pytest/actions/runs/11251731388/job/31283399122