### PR TITLE
chore: drop Python 3.8

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -31,7 +31,7 @@ extends:
         steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.8'
+            versionSpec: '3.9'
           displayName: 'Use Python'
         - script: |
             python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: 3.11
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
+        python -m pip install --upgrade pip
         pip install -r local-requirements.txt
     - name: Lint
       run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: 3.11
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        pip install --upgrade pip
         pip install -r local-requirements.txt
     - name: Lint
       run: pre-commit run --show-diff-on-failure --color=always --all-files
@@ -24,8 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9', '3.10', '3.11']
+        include:
+          - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.13'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -34,12 +39,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install -r local-requirements.txt
         pip install -e .
-        python -m playwright install
-        python -m playwright install-deps
+        python -m playwright install --with-deps
+        if [ '${{ matrix.os }}' == 'macos-latest' ]; then
+          python -m playwright install msedge --with-deps
+        fi
     - name: Test
       if: ${{ matrix.os != 'ubuntu-latest' }}
       run: pytest --cov=pytest_playwright --cov-report xml

--- a/meta.yaml
+++ b/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - setuptools-scm
     - pip
   run:
-    - python >=3.8
+    - python >=3.9
     - microsoft::playwright >=1.37.0
     - pytest >=6.2.4,<9.0.0
     - pytest-base-url >=1.0.0,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ignore =
     E302
 [mypy]
 ignore_missing_imports = True
-python_version = 3.8
+python_version = 3.9
 warn_unused_ignores = False
 warn_redundant_casts = True
 warn_unused_configs = True

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,16 @@ setuptools.setup(
     entry_points={"pytest11": ["playwright = pytest_playwright.pytest_playwright"]},
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Framework :: Pytest",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     use_scm_version={
         "version_scheme": "post-release",
         "write_to": "pytest_playwright/_repo_version.py",


### PR DESCRIPTION
Similar to https://github.com/microsoft/playwright-python/commit/f7cfdac7152506c4c41931e453a1ce5dff0474d4 since its EOL and not supported anymore in our dev dependencies.