### PR TITLE
chore: leverage asyncio_default_test_loop_scope config option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
         pip install -r local-requirements.txt
         pip install -e pytest-playwright
         pip install -e pytest-playwright-asyncio
-        python -m playwright install --with-deps
+        playwright install --with-deps
         if [ '${{ matrix.os }}' == 'macos-latest' ]; then
-          python -m playwright install msedge --with-deps
+          playwright install msedge --with-deps
         fi
     - name: Test
       if: ${{ matrix.os != 'ubuntu-latest' }}

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -8,4 +8,4 @@ flake8==7.1.1
 pre-commit==4.0.1
 Django==4.2.18
 pytest-xdist==2.5.0
-pytest-asyncio==0.24.0
+pytest-asyncio==0.26.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ warn_unused_configs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 [tool:pytest]
-addopts = -p no:playwright -p no:playwright-asyncio --runpytest subprocess -vv
+addopts = -p no:asyncio -p no:playwright -p no:playwright-asyncio --runpytest subprocess -vv
 testpaths =
     tests


### PR DESCRIPTION
This PR does not include any user-facing changes - its only about our tests. There it updates the `pytest-asyncio` plugin and leverages the new config option which simplifies it.

Relates https://github.com/microsoft/playwright-python/issues/2742.