### PR TITLE
Make 'browser_name' parameter indirect

### DIFF
--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -92,7 +92,7 @@ def delete_output_dir(pytestconfig: Any) -> None:
 def pytest_generate_tests(metafunc: Any) -> None:
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
-        metafunc.parametrize("browser_name", browsers, scope="session")
+        metafunc.parametrize("browser_name", browsers, scope="session", indirect=True)
 
 
 def pytest_configure(config: Any) -> None:
@@ -389,7 +389,10 @@ def is_chromium(browser_name: str) -> bool:
 
 
 @pytest.fixture(scope="session")
-def browser_name(pytestconfig: Any) -> Optional[str]:
+def browser_name(pytestconfig: Any, request: pytest.FixtureRequest) -> Optional[str]:
+    if hasattr(request, "param"):
+        return request.param
+
     # When using unittest.TestCase it won't use pytest_generate_tests
     # For that we still try to give the user a slightly less feature-rich experience
     browser_names = pytestconfig.getoption("--browser")

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -89,7 +89,7 @@ def delete_output_dir(pytestconfig: Any) -> None:
 def pytest_generate_tests(metafunc: Any) -> None:
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
-        metafunc.parametrize("browser_name", browsers, scope="session")
+        metafunc.parametrize("browser_name", browsers, scope="session", indirect=True)
 
 
 def pytest_configure(config: Any) -> None:
@@ -384,7 +384,10 @@ def is_chromium(browser_name: str) -> bool:
 
 
 @pytest.fixture(scope="session")
-def browser_name(pytestconfig: Any) -> Optional[str]:
+def browser_name(pytestconfig: Any, request: pytest.FixtureRequest) -> Optional[str]:
+    if hasattr(request, "param"):
+        return request.param
+
     # When using unittest.TestCase it won't use pytest_generate_tests
     # For that we still try to give the user a slightly less feature-rich experience
     browser_names = pytestconfig.getoption("--browser")


### PR DESCRIPTION
Fixes #195.

Using `"browser_name"` as an indirect parameter, pytest keeps the original order of the tests.

Without pytest-playwright:
```
my_tests/test_a.py::test_aa[case_1] PASSED                                                 [ 12%]
my_tests/test_a.py::test_aa[case_2] PASSED                                                 [ 25%]
my_tests/test_a.py::test_ab[case_1] PASSED                                                 [ 37%]
my_tests/test_a.py::test_ab[case_2] PASSED                                                 [ 50%]
my_tests/test_b.py::test_ba[case_1] PASSED                                                 [ 62%]
my_tests/test_b.py::test_ba[case_2] PASSED                                                 [ 75%]
my_tests/test_b.py::test_bb[case_1] PASSED                                                 [ 87%]
my_tests/test_b.py::test_bb[case_2] PASSED                                                 [100%]
```

With pytest-playwright before the fix:
```
my_tests/test_a.py::test_aa[chromium-case_1] PASSED                                        [  4%]
my_tests/test_a.py::test_ab[chromium-case_1] PASSED                                        [  8%]
my_tests/test_b.py::test_ba[chromium-case_1] PASSED                                        [ 12%]
my_tests/test_b.py::test_bb[chromium-case_1] PASSED                                        [ 16%]
my_tests/test_a.py::test_aa[chromium-case_2] PASSED                                        [ 20%]
my_tests/test_a.py::test_ab[chromium-case_2] PASSED                                        [ 25%]
my_tests/test_b.py::test_ba[chromium-case_2] PASSED                                        [ 29%]
my_tests/test_b.py::test_bb[chromium-case_2] PASSED                                        [ 33%]
my_tests/test_a.py::test_aa[firefox-case_1] PASSED                                         [ 37%]
my_tests/test_a.py::test_ab[firefox-case_1] PASSED                                         [ 41%]
my_tests/test_b.py::test_ba[firefox-case_1] PASSED                                         [ 45%]
my_tests/test_b.py::test_bb[firefox-case_1] PASSED                                         [ 50%]
my_tests/test_a.py::test_aa[firefox-case_2] PASSED                                         [ 54%]
my_tests/test_a.py::test_ab[firefox-case_2] PASSED                                         [ 58%]
my_tests/test_b.py::test_ba[firefox-case_2] PASSED                                         [ 62%]
my_tests/test_b.py::test_bb[firefox-case_2] PASSED                                         [ 66%]
my_tests/test_a.py::test_aa[webkit-case_1] PASSED                                          [ 70%]
my_tests/test_a.py::test_ab[webkit-case_1] PASSED                                          [ 75%]
my_tests/test_b.py::test_ba[webkit-case_1] PASSED                                          [ 79%]
my_tests/test_b.py::test_bb[webkit-case_1] PASSED                                          [ 83%]
my_tests/test_a.py::test_aa[webkit-case_2] PASSED                                          [ 87%]
my_tests/test_a.py::test_ab[webkit-case_2] PASSED                                          [ 91%]
my_tests/test_b.py::test_ba[webkit-case_2] PASSED                                          [ 95%]
my_tests/test_b.py::test_bb[webkit-case_2] PASSED                                          [100%]
```

With pytest-playwright after the fix:
```
my_tests/test_a.py::test_aa[chromium-case_1] PASSED                                        [  4%]
my_tests/test_a.py::test_aa[chromium-case_2] PASSED                                        [  8%]
my_tests/test_a.py::test_ab[chromium-case_1] PASSED                                        [ 12%]
my_tests/test_a.py::test_ab[chromium-case_2] PASSED                                        [ 16%]
my_tests/test_b.py::test_ba[chromium-case_1] PASSED                                        [ 20%]
my_tests/test_b.py::test_ba[chromium-case_2] PASSED                                        [ 25%]
my_tests/test_b.py::test_bb[chromium-case_1] PASSED                                        [ 29%]
my_tests/test_b.py::test_bb[chromium-case_2] PASSED                                        [ 33%]
my_tests/test_a.py::test_aa[firefox-case_1] PASSED                                         [ 37%]
my_tests/test_a.py::test_aa[firefox-case_2] PASSED                                         [ 41%]
my_tests/test_a.py::test_ab[firefox-case_1] PASSED                                         [ 45%]
my_tests/test_a.py::test_ab[firefox-case_2] PASSED                                         [ 50%]
my_tests/test_b.py::test_ba[firefox-case_1] PASSED                                         [ 54%]
my_tests/test_b.py::test_ba[firefox-case_2] PASSED                                         [ 58%]
my_tests/test_b.py::test_bb[firefox-case_1] PASSED                                         [ 62%]
my_tests/test_b.py::test_bb[firefox-case_2] PASSED                                         [ 66%]
my_tests/test_a.py::test_aa[webkit-case_1] PASSED                                          [ 70%]
my_tests/test_a.py::test_aa[webkit-case_2] PASSED                                          [ 75%]
my_tests/test_a.py::test_ab[webkit-case_1] PASSED                                          [ 79%]
my_tests/test_a.py::test_ab[webkit-case_2] PASSED                                          [ 83%]
my_tests/test_b.py::test_ba[webkit-case_1] PASSED                                          [ 87%]
my_tests/test_b.py::test_ba[webkit-case_2] PASSED                                          [ 91%]
my_tests/test_b.py::test_bb[webkit-case_1] PASSED                                          [ 95%]
my_tests/test_b.py::test_bb[webkit-case_2] PASSED                                          [100%]
```