### PR TITLE
Fix 'test_is_able_to_set_expect_timeout_via_conftest' tests

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -810,7 +810,7 @@ def test_is_able_to_set_expect_timeout_via_conftest(testdir: pytest.Testdir) -> 
     result = testdir.runpytest()
     result.assert_outcomes(passed=0, failed=1, skipped=0)
     result.stdout.fnmatch_lines("*AssertionError: Locator expected to be visible*")
-    result.stdout.fnmatch_lines("*LocatorAssertions.to_be_visible with timeout 1111ms*")
+    result.stdout.fnmatch_lines('*Expect "to_be_visible" with timeout 1111ms*')
 
 
 def test_artifact_collection_should_work_for_manually_created_contexts_keep_open(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -808,7 +808,7 @@ def test_is_able_to_set_expect_timeout_via_conftest(testdir: pytest.Testdir) -> 
     result = testdir.runpytest()
     result.assert_outcomes(passed=0, failed=1, skipped=0)
     result.stdout.fnmatch_lines("*AssertionError: Locator expected to be visible*")
-    result.stdout.fnmatch_lines("*LocatorAssertions.to_be_visible with timeout 1111ms*")
+    result.stdout.fnmatch_lines('*Expect "to_be_visible" with timeout 1111ms*')
 
 
 def test_artifact_collection_should_work_for_manually_created_contexts_keep_open(


### PR DESCRIPTION
From playwright version 1.52 to version 1.53, the failure output has changed.

From this:
```
============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0
rootdir: /tmp/pytest-of-robertofernandez/pytest-22/test_is_able_to_set_expect_timeout_via_conftest0
configfile: pytest.ini
plugins: playwright-0.1.dev144+gdc15f33.d20250703, forked-1.6.0, xdist-2.5.0, base-url-2.1.0, asyncio-1.0.0, cov-3.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

test_is_able_to_set_expect_timeout_via_conftest.py F                     [100%]

=================================== FAILURES ===================================
_________________________ test_small_timeout[chromium] _________________________

page = <Page url='data:text/html,'>

    def test_small_timeout(page):
        page.goto("data:text/html,")
>       expect(page.locator("#A")).to_be_visible()
E       AssertionError: Locator expected to be visible
E       Actual value: <element(s) not found> 
E       Call log:
E         - LocatorAssertions.to_be_visible with timeout 1111ms
E         - waiting for locator("#A")

test_is_able_to_set_expect_timeout_via_conftest.py:5: AssertionError
=========================== short test summary info ============================
FAILED test_is_able_to_set_expect_timeout_via_conftest.py::test_small_timeout[chromium]
============================== 1 failed in 1.95s ===============================
```

To this:
```
============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0
rootdir: /tmp/pytest-of-robertofernandez/pytest-24/test_is_able_to_set_expect_timeout_via_conftest0
configfile: pytest.ini
plugins: playwright-0.1.dev144+gdc15f33.d20250703, forked-1.6.0, xdist-2.5.0, base-url-2.1.0, asyncio-1.0.0, cov-3.0.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

test_is_able_to_set_expect_timeout_via_conftest.py F                     [100%]

=================================== FAILURES ===================================
_________________________ test_small_timeout[chromium] _________________________

page = <Page url='data:text/html,'>

    def test_small_timeout(page):
        page.goto("data:text/html,")
>       expect(page.locator("#A")).to_be_visible()
E       AssertionError: Locator expected to be visible
E       Actual value: <element(s) not found> 
E       Call log:
E         - Expect "to_be_visible" with timeout 1111ms
E         - waiting for locator("#A")

test_is_able_to_set_expect_timeout_via_conftest.py:5: AssertionError
=========================== short test summary info ============================
FAILED test_is_able_to_set_expect_timeout_via_conftest.py::test_small_timeout[chromium]
============================== 1 failed in 1.89s ===============================
```

So, expected text in `test_is_able_to_set_expect_timeout_via_conftest` has been changed accordingly.