### PR TITLE
fix: use png screenshot type after Playwright v1.55.0 alignment

### DIFF
--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -600,6 +600,7 @@ class ArtifactsRecorder:
                     await page.screenshot(
                         timeout=5000,
                         path=screenshot_path,
+                        type="png",
                         full_page=self._pytestconfig.getoption(
                             "--full-page-screenshot"
                         ),

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -595,6 +595,7 @@ class ArtifactsRecorder:
                     page.screenshot(
                         timeout=5000,
                         path=screenshot_path,
+                        type="png",
                         full_page=self._pytestconfig.getoption(
                             "--full-page-screenshot"
                         ),


### PR DESCRIPTION
This fixes https://github.com/microsoft/playwright-python/issues/2965 in the `pytest-playwright` project rather than in the `playwright-playwright` project which seems more reasonable, since it keeps it aligned on how we do it in upstream Playwright.

NOTE: The regression was triggered after a change of the screenshot type determination logic in the `playwright-python` project: https://github.com/microsoft/playwright-python/pull/2951

Fixes https://github.com/microsoft/playwright-python/issues/2965
Closes https://github.com/microsoft/playwright-python/pull/2951