### PR TITLE
devops: fix AzDO publishing pipeline

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -44,34 +44,34 @@ extends:
             python -m build --outdir $(Build.ArtifactStagingDirectory)/esrp-build pytest-playwright
             python -m build --outdir $(Build.ArtifactStagingDirectory)/esrp-build pytest-playwright-asyncio
           displayName: 'Install & Build'
-    - job: Publish
-      dependsOn: Build
-      templateContext:
-        type: releaseJob
-        isProduction: true
-        inputs:
-        - input: pipelineArtifact
-          artifactName: esrp-build
-          targetPath: $(Build.ArtifactStagingDirectory)/esrp-build
-      steps:
-        - checkout: none
-        - task: EsrpRelease@9
+      - job: Publish
+        dependsOn: Build
+        templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
-            connectedservicename: 'Playwright-ESRP-PME'
-            usemanagedidentity: true
-            keyvaultname: 'playwright-esrp-pme'
-            signcertname: 'ESRP-Release-Sign'
-            clientid: '13434a40-7de4-4c23-81a3-d843dc81c2c5'
-            intent: 'PackageDistribution'
-            contenttype: 'PyPi'
-            # Keeping it commented out as a workaround for:
-            # https://portal.microsofticm.com/imp/v3/incidents/incident/499972482/summary
-            # contentsource: 'folder'
-            folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
-            waitforreleasecompletion: true
-            owners: 'maxschmitt@microsoft.com'
-            approvers: 'maxschmitt@microsoft.com'
-            serviceendpointurl: 'https://api.esrp.microsoft.com'
-            mainpublisher: 'Playwright'
-            domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
-          displayName: 'ESRP Release to PIP'
+          - input: pipelineArtifact
+            artifactName: esrp-build
+            targetPath: $(Build.ArtifactStagingDirectory)/esrp-build
+        steps:
+          - checkout: none
+          - task: EsrpRelease@9
+            inputs:
+              connectedservicename: 'Playwright-ESRP-PME'
+              usemanagedidentity: true
+              keyvaultname: 'playwright-esrp-pme'
+              signcertname: 'ESRP-Release-Sign'
+              clientid: '13434a40-7de4-4c23-81a3-d843dc81c2c5'
+              intent: 'PackageDistribution'
+              contenttype: 'PyPi'
+              # Keeping it commented out as a workaround for:
+              # https://portal.microsofticm.com/imp/v3/incidents/incident/499972482/summary
+              # contentsource: 'folder'
+              folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
+              waitforreleasecompletion: true
+              owners: 'maxschmitt@microsoft.com'
+              approvers: 'maxschmitt@microsoft.com'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'Playwright'
+              domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+            displayName: 'ESRP Release to PIP'


### PR DESCRIPTION
<img width="1180" height="370" alt="Screenshot 2025-09-08 at 09 39 35" src="https://github.com/user-attachments/assets/8e4341bd-dcdd-4cda-98f7-37f3947dc509" />

There was an indentation issue before.