### PR TITLE
feat: allow browser_name as parametrize

### DIFF
--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -92,7 +92,8 @@ def delete_output_dir(pytestconfig: Any) -> None:
 def pytest_generate_tests(metafunc: Any) -> None:
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
-        metafunc.parametrize("browser_name", browsers, scope="session")
+        if "browser_name" not in getattr(metafunc, "params", {}):
+            metafunc.parametrize("browser_name", browsers, scope="session")
 
 
 def pytest_configure(config: Any) -> None:

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -89,7 +89,8 @@ def delete_output_dir(pytestconfig: Any) -> None:
 def pytest_generate_tests(metafunc: Any) -> None:
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
-        metafunc.parametrize("browser_name", browsers, scope="session")
+        if "browser_name" not in getattr(metafunc, "params", {}):
+            metafunc.parametrize("browser_name", browsers, scope="session")
 
 
 def pytest_configure(config: Any) -> None:


### PR DESCRIPTION
The browser_name is only get from pytest execution parameters and default add to tests. But if we need to mark part of tests as multi browser test, will meet error about the default action.

This PR is enable the browser_name can added as mark.parametrize.