### PR TITLE
fix: check common name for incompatible plugin

### DIFF
--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -413,14 +413,24 @@ def device(pytestconfig: Any) -> Optional[str]:
     return pytestconfig.getoption("--device")
 
 
+PW_SYNC_CANONICAL_NAME = "pytest_playwright.pytest_playwright"
+PLUGIN_INCOMPATIBLE_MESSAGE = "pytest-playwright and pytest-playwright-asyncio are not compatible. Please use only one of them."
+
+
 def pytest_addoption(
     parser: pytest.Parser, pluginmanager: pytest.PytestPluginManager
 ) -> None:
-    # Check for incompatible sync plugin early
-    if pluginmanager.has_plugin("pytest_playwright.pytest_playwright"):
-        raise RuntimeError(
-            "pytest-playwright and pytest-playwright-asyncio are not compatible. Please use only one of them."
-        )
+    # Check for incompatible sync plugin with canonical name
+    if pluginmanager.has_plugin(PW_SYNC_CANONICAL_NAME):
+        raise RuntimeError(PLUGIN_INCOMPATIBLE_MESSAGE)
+    # Check for incompatible sync plugin with common name
+    common_name_plugin = pluginmanager.get_plugin("playwright")
+    if (
+        common_name_plugin is not None
+        and pluginmanager.get_canonical_name(common_name_plugin)
+        == PW_SYNC_CANONICAL_NAME
+    ):
+        raise RuntimeError(PLUGIN_INCOMPATIBLE_MESSAGE)
     group = parser.getgroup("playwright", "Playwright")
     group.addoption(
         "--browser",

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -408,14 +408,24 @@ def device(pytestconfig: Any) -> Optional[str]:
     return pytestconfig.getoption("--device")
 
 
+PW_ASYNC_CANONICAL_NAME = "pytest_playwright_asyncio.pytest_playwright"
+PLUGIN_INCOMPATIBLE_MESSAGE = "pytest-playwright and pytest-playwright-asyncio are not compatible. Please use only one of them."
+
+
 def pytest_addoption(
     parser: pytest.Parser, pluginmanager: pytest.PytestPluginManager
 ) -> None:
-    # Check for incompatible async plugin early
-    if pluginmanager.has_plugin("pytest_playwright_asyncio.pytest_playwright"):
-        raise RuntimeError(
-            "pytest-playwright and pytest-playwright-asyncio are not compatible. Please use only one of them."
-        )
+    # Check for incompatible async plugin with canonical name
+    if pluginmanager.has_plugin(PW_ASYNC_CANONICAL_NAME):
+        raise RuntimeError(PLUGIN_INCOMPATIBLE_MESSAGE)
+    # Check for incompatible async plugin with common name
+    common_name_plugin = pluginmanager.get_plugin("playwright-asyncio")
+    if (
+        common_name_plugin is not None
+        and pluginmanager.get_canonical_name(common_name_plugin)
+        == PW_ASYNC_CANONICAL_NAME
+    ):
+        raise RuntimeError(PLUGIN_INCOMPATIBLE_MESSAGE)
     group = parser.getgroup("playwright", "Playwright")
     group.addoption(
         "--browser",


### PR DESCRIPTION
Currently, the plugins check for the full names of the other plugin (`pytest_playwright.pytest_playwright` in async, and `pytest_playwright_asyncio.pytest_playwright` in sync) against the `PytestPluginManager`'s name-to-plugin `dict`, in order to error if the other, incompatible, plugin has been loaded.

However, in my project (and it seems like this is pretty common), plugins will be registered under the "common" name:

<img width="591" height="38" alt="image" src="https://github.com/user-attachments/assets/414ac19a-9a84-46e0-9427-e531dea14ca1" />

And so this will fail to raise the error, and we will get this one instead which is much less helpful:

<img width="445" height="237" alt="image" src="https://github.com/user-attachments/assets/32d22ed1-3796-4f31-97d7-bb08495369c5" />

This PR does an additional check for the "common" name, and then checks that the plugin itself has the matching canonical name, which should now handle this case.

As far as I can see, I couldn't find a decent way to register a plugin under a different name as part of the `pytest` invocation, and so I haven't added the additional test case.

In the given example above though, this now gives us the expected error:
<img width="789" height="87" alt="image" src="https://github.com/user-attachments/assets/a0d63ffa-b532-4806-a656-c0fd31e054dc" />