### PR TITLE
chore: drop Python 3.9

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -36,7 +36,7 @@ extends:
         steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.9'
+            versionSpec: '3.10'
           displayName: 'Use Python'
         - script: |
             python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         include:
-          - os: ubuntu-latest
-            python-version: '3.12'
           - os: ubuntu-latest
             python-version: '3.13'
     runs-on: ${{ matrix.os }}
@@ -69,7 +67,7 @@ jobs:
       - name: Get conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
           channels: microsoft,conda-forge
       - name: Prepare
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
           channels: microsoft,conda-forge
       - name: Prepare
         run: |

--- a/meta.yaml
+++ b/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - setuptools-scm
     - pip
   run:
-    - python >=3.9
+    - python >=3.10
     - microsoft::playwright >=1.37.0
     - pytest >=6.2.4,<9.0.0
     - pytest-base-url >=1.0.0,<3.0.0

--- a/pytest-playwright-asyncio/pyproject.toml
+++ b/pytest-playwright-asyncio/pyproject.toml
@@ -10,10 +10,9 @@ authors = [
     {name = "Microsoft"}
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pytest-playwright/pyproject.toml
+++ b/pytest-playwright/pyproject.toml
@@ -10,10 +10,9 @@ authors = [
     {name = "Microsoft"}
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ ignore =
     E704
 [mypy]
 ignore_missing_imports = True
-python_version = 3.9
+python_version = 3.10
 warn_unused_ignores = False
 warn_redundant_casts = True
 warn_unused_configs = True


### PR DESCRIPTION
This is needed to allow Pytest 9 which [dropped support for Python 3.9](https://docs.pytest.org/en/stable/changelog.html#removals-and-backward-incompatible-breaking-changes) since its EOL.

Relates https://github.com/microsoft/playwright-pytest/issues/298

cc @skn0tt