### PR TITLE
feat: aggregate expect.soft() failures per test

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -55,7 +55,7 @@ extends:
             targetPath: $(Build.ArtifactStagingDirectory)/esrp-build
         steps:
           - checkout: none
-          - task: EsrpRelease@10
+          - task: EsrpRelease@11
             inputs:
               connectedservicename: 'Playwright-ESRP-PME'
               usemanagedidentity: true

--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -37,6 +37,12 @@ from typing import (
 )
 
 import pytest
+
+if sys.version_info >= (3, 11):
+    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
+else:
+    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
+
 from playwright._impl._assertions import _soft_scope
 from playwright.async_api import (
     Browser,
@@ -88,12 +94,6 @@ def delete_output_dir(pytestconfig: Any) -> None:
             entries = os.listdir(output_dir)
             for entry in entries:
                 shutil.rmtree(entry)
-
-
-if sys.version_info >= (3, 11):
-    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
-else:
-    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
 
 
 @pytest.fixture(autouse=True)

--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -37,6 +37,7 @@ from typing import (
 )
 
 import pytest
+from playwright._impl._assertions import _soft_scope
 from playwright.async_api import (
     Browser,
     BrowserContext,
@@ -87,6 +88,23 @@ def delete_output_dir(pytestconfig: Any) -> None:
             entries = os.listdir(output_dir)
             for entry in entries:
                 shutil.rmtree(entry)
+
+
+if sys.version_info >= (3, 11):
+    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
+else:
+    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
+
+
+@pytest.fixture(autouse=True)
+def _playwright_soft_assertions() -> Generator[None, None, None]:
+    with _soft_scope() as errors:
+        yield
+    if not errors:
+        return
+    if len(errors) == 1:
+        raise errors[0]
+    raise _BaseExceptionGroup("Soft assertion failures", errors)
 
 
 def pytest_generate_tests(metafunc: Any) -> None:

--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -43,7 +43,10 @@ if sys.version_info >= (3, 11):
 else:
     from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
 
-from playwright._impl._assertions import _soft_scope
+try:
+    from playwright._impl._assertions import _soft_scope
+except ImportError:
+    _soft_scope = None
 from playwright.async_api import (
     Browser,
     BrowserContext,
@@ -96,12 +99,25 @@ def delete_output_dir(pytestconfig: Any) -> None:
                 shutil.rmtree(entry)
 
 
-@pytest.fixture(autouse=True)
-def _playwright_soft_assertions() -> Generator[None, None, None]:
-    with _soft_scope() as errors:
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_call(item: Any) -> Generator[None, Any, None]:
+    if _soft_scope is None:
         yield
-    if not errors:
         return
+    hard_failure: Optional[BaseException] = None
+    with _soft_scope() as errors:
+        try:
+            yield
+        except BaseException as exc:
+            hard_failure = exc
+    if not errors:
+        if hard_failure is not None:
+            raise hard_failure
+        return
+    if hard_failure is not None:
+        raise _BaseExceptionGroup(
+            "Test and soft assertion failures", [hard_failure, *errors]
+        )
     if len(errors) == 1:
         raise errors[0]
     raise _BaseExceptionGroup("Soft assertion failures", errors)

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -35,6 +35,7 @@ from typing import (
 )
 
 import pytest
+from playwright._impl._assertions import _soft_scope
 from playwright.sync_api import (
     Browser,
     BrowserContext,
@@ -84,6 +85,23 @@ def delete_output_dir(pytestconfig: Any) -> None:
             entries = os.listdir(output_dir)
             for entry in entries:
                 shutil.rmtree(entry)
+
+
+if sys.version_info >= (3, 11):
+    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
+else:
+    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
+
+
+@pytest.fixture(autouse=True)
+def _playwright_soft_assertions() -> Generator[None, None, None]:
+    with _soft_scope() as errors:
+        yield
+    if not errors:
+        return
+    if len(errors) == 1:
+        raise errors[0]
+    raise _BaseExceptionGroup("Soft assertion failures", errors)
 
 
 def pytest_generate_tests(metafunc: Any) -> None:

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -41,7 +41,10 @@ if sys.version_info >= (3, 11):
 else:
     from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
 
-from playwright._impl._assertions import _soft_scope
+try:
+    from playwright._impl._assertions import _soft_scope
+except ImportError:
+    _soft_scope = None
 from playwright.sync_api import (
     Browser,
     BrowserContext,
@@ -93,12 +96,25 @@ def delete_output_dir(pytestconfig: Any) -> None:
                 shutil.rmtree(entry)
 
 
-@pytest.fixture(autouse=True)
-def _playwright_soft_assertions() -> Generator[None, None, None]:
-    with _soft_scope() as errors:
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_call(item: Any) -> Generator[None, Any, None]:
+    if _soft_scope is None:
         yield
-    if not errors:
         return
+    hard_failure: Optional[BaseException] = None
+    with _soft_scope() as errors:
+        try:
+            yield
+        except BaseException as exc:
+            hard_failure = exc
+    if not errors:
+        if hard_failure is not None:
+            raise hard_failure
+        return
+    if hard_failure is not None:
+        raise _BaseExceptionGroup(
+            "Test and soft assertion failures", [hard_failure, *errors]
+        )
     if len(errors) == 1:
         raise errors[0]
     raise _BaseExceptionGroup("Soft assertion failures", errors)

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -35,6 +35,12 @@ from typing import (
 )
 
 import pytest
+
+if sys.version_info >= (3, 11):
+    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
+else:
+    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
+
 from playwright._impl._assertions import _soft_scope
 from playwright.sync_api import (
     Browser,
@@ -85,12 +91,6 @@ def delete_output_dir(pytestconfig: Any) -> None:
             entries = os.listdir(output_dir)
             for entry in entries:
                 shutil.rmtree(entry)
-
-
-if sys.version_info >= (3, 11):
-    _BaseExceptionGroup = BaseExceptionGroup  # noqa: F821
-else:
-    from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1091,3 +1091,57 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
         else:
             os.kill(server_process.pid, signal.SIGINT)
         server_process.wait()
+
+
+def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        from playwright.async_api import expect
+
+        @pytest.mark.asyncio
+        async def test_soft(page):
+            await page.set_content("<div>hello</div>")
+            await expect.soft(page.locator("div")).to_have_text("goodbye")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    assert any("goodbye" in line for line in result.outlines)
+
+
+def test_soft_assertion_multiple_failures_exception_group(
+    testdir: pytest.Testdir,
+) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        from playwright.async_api import expect
+
+        @pytest.mark.asyncio
+        async def test_soft(page):
+            await page.set_content("<div>hello</div>")
+            await expect.soft(page.locator("div")).to_have_text("first")
+            await expect.soft(page.locator("div")).to_have_text("second")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    out = "\n".join(result.outlines)
+    assert "first" in out and "second" in out
+
+
+def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        from playwright.async_api import expect
+
+        @pytest.mark.asyncio
+        async def test_soft(page):
+            await page.set_content("<div>hello</div>")
+            await expect.soft(page.locator("div")).to_have_text("hello")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1106,7 +1106,7 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     """
     )
     result = testdir.runpytest("--browser", "chromium")
-    result.assert_outcomes(passed=1, errors=1)
+    result.assert_outcomes(failed=1)
     assert any("goodbye" in line for line in result.outlines)
 
 
@@ -1126,7 +1126,7 @@ def test_soft_assertion_multiple_failures_exception_group(
     """
     )
     result = testdir.runpytest("--browser", "chromium")
-    result.assert_outcomes(passed=1, errors=1)
+    result.assert_outcomes(failed=1)
     out = "\n".join(result.outlines)
     assert "first" in out and "second" in out
 
@@ -1145,3 +1145,26 @@ def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     )
     result = testdir.runpytest("--browser", "chromium")
     result.assert_outcomes(passed=1)
+
+
+def test_soft_assertion_does_not_shadow_body_failure(
+    testdir: pytest.Testdir,
+) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        from playwright.async_api import expect
+
+        @pytest.mark.asyncio
+        async def test_soft(page):
+            await page.set_content("<div>hello</div>")
+            await expect.soft(page.locator("div")).to_have_text("soft-fail")
+            raise RuntimeError("body-fail")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    # Body and soft assertion failures are grouped in call phase.
+    result.assert_outcomes(failed=1)
+    out = "\n".join(result.outlines)
+    assert "body-fail" in out
+    assert "soft-fail" in out

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1045,6 +1045,7 @@ def test_with_page(page):
     ]
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
     server_process = None
     try:
@@ -1110,6 +1111,7 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     assert any("goodbye" in line for line in result.outlines)
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_multiple_failures_exception_group(
     testdir: pytest.Testdir,
 ) -> None:
@@ -1131,6 +1133,7 @@ def test_soft_assertion_multiple_failures_exception_group(
     assert "first" in out and "second" in out
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(
         """
@@ -1147,6 +1150,7 @@ def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_does_not_shadow_body_failure(
     testdir: pytest.Testdir,
 ) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1090,7 +1090,7 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     """
     )
     result = testdir.runpytest("--browser", "chromium")
-    result.assert_outcomes(passed=1, errors=1)
+    result.assert_outcomes(failed=1)
     assert any("goodbye" in line for line in result.outlines)
 
 
@@ -1108,7 +1108,7 @@ def test_soft_assertion_multiple_failures_exception_group(
     """
     )
     result = testdir.runpytest("--browser", "chromium")
-    result.assert_outcomes(passed=1, errors=1)
+    result.assert_outcomes(failed=1)
     out = "\n".join(result.outlines)
     assert "first" in out and "second" in out
 
@@ -1141,8 +1141,8 @@ def test_soft_assertion_does_not_shadow_body_failure(
     """
     )
     result = testdir.runpytest("--browser", "chromium")
-    # Body raises during call, soft assertion raises during teardown.
-    result.assert_outcomes(failed=1, errors=1)
+    # Body and soft assertion failures are grouped in call phase.
+    result.assert_outcomes(failed=1)
     out = "\n".join(result.outlines)
     assert "body-fail" in out
     assert "soft-fail" in out

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1035,6 +1035,7 @@ def test_with_page(page):
     ]
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
     server_process = None
     try:
@@ -1094,6 +1095,7 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     assert any("goodbye" in line for line in result.outlines)
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_multiple_failures_exception_group(
     testdir: pytest.Testdir,
 ) -> None:
@@ -1113,6 +1115,7 @@ def test_soft_assertion_multiple_failures_exception_group(
     assert "first" in out and "second" in out
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(
         """
@@ -1127,6 +1130,7 @@ def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
+@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_does_not_shadow_body_failure(
     testdir: pytest.Testdir,
 ) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1077,3 +1077,72 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
         else:
             os.kill(server_process.pid, signal.SIGINT)
         server_process.wait()
+
+
+def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        from playwright.sync_api import expect
+
+        def test_soft(page):
+            page.set_content("<div>hello</div>")
+            expect.soft(page.locator("div")).to_have_text("goodbye")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    assert any("goodbye" in line for line in result.outlines)
+
+
+def test_soft_assertion_multiple_failures_exception_group(
+    testdir: pytest.Testdir,
+) -> None:
+    testdir.makepyfile(
+        """
+        from playwright.sync_api import expect
+
+        def test_soft(page):
+            page.set_content("<div>hello</div>")
+            expect.soft(page.locator("div")).to_have_text("first")
+            expect.soft(page.locator("div")).to_have_text("second")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1, errors=1)
+    out = "\n".join(result.outlines)
+    assert "first" in out and "second" in out
+
+
+def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
+    testdir.makepyfile(
+        """
+        from playwright.sync_api import expect
+
+        def test_soft(page):
+            page.set_content("<div>hello</div>")
+            expect.soft(page.locator("div")).to_have_text("hello")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    result.assert_outcomes(passed=1)
+
+
+def test_soft_assertion_does_not_shadow_body_failure(
+    testdir: pytest.Testdir,
+) -> None:
+    testdir.makepyfile(
+        """
+        from playwright.sync_api import expect
+
+        def test_soft(page):
+            page.set_content("<div>hello</div>")
+            expect.soft(page.locator("div")).to_have_text("soft-fail")
+            raise RuntimeError("body-fail")
+    """
+    )
+    result = testdir.runpytest("--browser", "chromium")
+    # Body raises during call, soft assertion raises during teardown.
+    result.assert_outcomes(failed=1, errors=1)
+    out = "\n".join(result.outlines)
+    assert "body-fail" in out
+    assert "soft-fail" in out


### PR DESCRIPTION
## Summary
- Moves soft assertion collection from fixture teardown to test call phase using `pytest_runtest_call` hook.
- At end of test: 0 failures → noop, 1 failure → re-raise as FAILED, ≥2 failures → raise `ExceptionGroup` as FAILED.
- Eliminates spurious "passed" entries when soft assertions fail—the test is correctly reported as FAILED, not passed+failed.
- Requires `playwright-python` with the soft-assertions hook (microsoft/playwright-python#3065).
- Backward-compatible with older Playwright versions that lack soft-assertions support.

Companion PR (core hook): microsoft/playwright-python#3065

## Example output

When running tests with one single soft failure, multiple soft failures, one passing case, and one soft+body failure case:

- Single soft failure is reported as `FAILED` with the assertion details (e.g. expected 'goodbye', actual 'hello').
- Multiple soft failures are reported as `FAILED` with an `ExceptionGroup` containing each soft failure.
- Matching soft assertions pass cleanly.
- A body exception plus a soft assertion failure reports both in a grouped `ExceptionGroup` as `FAILED`.

```text
FAILED tests/test_soft.py::test_soft_plus_body_failure - ExceptionGroup: Test and soft assertion failures (2 sub-exceptions)
FAILED tests/test_soft.py::test_single_soft_failure - AssertionError: Locator expected to have text 'goodbye'
FAILED tests/test_soft.py::test_multiple_soft_failures - ExceptionGroup: Soft assertion failures (2 sub-exceptions)
PASSED tests/test_soft.py::test_soft_passes
```
