### PR TITLE
chore: require playwright>=1.60 in CI and unskip 1.60 tests

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -9,3 +9,4 @@ pre-commit==4.0.1
 Django==4.2.24
 pytest-xdist==3.8.0
 pytest-asyncio==1.3.0
+playwright>=1.60

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,10 @@ elif sys.platform == "win32":
 
 os.environ["PLAYWRIGHT_BROWSERS_PATH"] = playwright_browser_path
 
+# Ensure subprocess pytester runs (and any child python processes) emit utf-8
+# on stdout/stderr so pytester's utf-8 decoding doesn't break on Windows.
+os.environ["PYTHONIOENCODING"] = "utf-8"
+
 
 class HTTPTestServer:
     PREFIX = ""

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1045,7 +1045,6 @@ def test_with_page(page):
     ]
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
     server_process = None
     try:
@@ -1111,7 +1110,6 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     assert any("goodbye" in line for line in result.outlines)
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_multiple_failures_exception_group(
     testdir: pytest.Testdir,
 ) -> None:
@@ -1133,7 +1131,6 @@ def test_soft_assertion_multiple_failures_exception_group(
     assert "first" in out and "second" in out
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(
         """
@@ -1150,7 +1147,6 @@ def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_does_not_shadow_body_failure(
     testdir: pytest.Testdir,
 ) -> None:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1055,7 +1055,7 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
             @pytest.fixture(scope="session")
             def connect_options():
                 return {
-                    "ws_endpoint": "ws://localhost:1234",
+                    "endpoint": "ws://localhost:1234",
                 }
             """
         )
@@ -1069,7 +1069,7 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
             """
         )
         result = testdir.runpytest()
-        assert "connect ECONNREFUSED" in "".join(result.outlines)
+        assert "connect ECONNREFUSED" in "\n".join(result.outlines + result.errlines)
         server_process = subprocess.Popen(
             ["playwright", "run-server", "--port=1234"],
             stdout=subprocess.PIPE,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1035,7 +1035,6 @@ def test_with_page(page):
     ]
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
     server_process = None
     try:
@@ -1095,7 +1094,6 @@ def test_soft_assertion_single_failure(testdir: pytest.Testdir) -> None:
     assert any("goodbye" in line for line in result.outlines)
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_multiple_failures_exception_group(
     testdir: pytest.Testdir,
 ) -> None:
@@ -1115,7 +1113,6 @@ def test_soft_assertion_multiple_failures_exception_group(
     assert "first" in out and "second" in out
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     testdir.makepyfile(
         """
@@ -1130,7 +1127,6 @@ def test_soft_assertion_passes_when_all_match(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.skip(reason="requires 1.60")
 def test_soft_assertion_does_not_shadow_body_failure(
     testdir: pytest.Testdir,
 ) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1045,7 +1045,7 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
             @pytest.fixture(scope="session")
             def connect_options():
                 return {
-                    "ws_endpoint": "ws://localhost:1234",
+                    "endpoint": "ws://localhost:1234",
                 }
             """
         )
@@ -1056,7 +1056,7 @@ def test_connect_options_should_work(testdir: pytest.Testdir) -> None:
             """
         )
         result = testdir.runpytest()
-        assert "connect ECONNREFUSED" in "".join(result.outlines)
+        assert "connect ECONNREFUSED" in "\n".join(result.outlines + result.errlines)
         server_process = subprocess.Popen(
             ["playwright", "run-server", "--port=1234"],
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Playwright Python 1.60 has been released, so the tests gated on it can now run. Pin the dev dependency in `local-requirements.txt` so CI installs a compatible version; the package's runtime requirement (`playwright>=1.18`) is unchanged.