### PR TITLE
fix: keep multi-browser parametrization when the page fixture is overridden

### DIFF
--- a/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
+++ b/pytest-playwright-asyncio/pytest_playwright_asyncio/pytest_playwright.py
@@ -123,7 +123,20 @@ def pytest_runtest_call(item: Any) -> Generator[None, Any, None]:
     raise _BaseExceptionGroup("Soft assertion failures", errors)
 
 
+# Fixtures defined by this plugin that (transitively) require a browser and
+# therefore "browser_name". When one of them is requested through a user
+# override of e.g. the "page" fixture, some pytest versions drop "browser_name"
+# from the fixture closure, which would silently disable running the test
+# against multiple browsers.
+# https://github.com/microsoft/playwright-pytest/issues/172
+_BROWSER_FIXTURES = ("page", "context", "new_context", "browser", "browser_type")
+
+
 def pytest_generate_tests(metafunc: Any) -> None:
+    if "browser_name" not in metafunc.fixturenames and any(
+        name in metafunc.fixturenames for name in _BROWSER_FIXTURES
+    ):
+        metafunc.fixturenames.append("browser_name")
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
         metafunc.parametrize("browser_name", browsers, scope="session")

--- a/pytest-playwright/pytest_playwright/pytest_playwright.py
+++ b/pytest-playwright/pytest_playwright/pytest_playwright.py
@@ -120,7 +120,20 @@ def pytest_runtest_call(item: Any) -> Generator[None, Any, None]:
     raise _BaseExceptionGroup("Soft assertion failures", errors)
 
 
+# Fixtures defined by this plugin that (transitively) require a browser and
+# therefore "browser_name". When one of them is requested through a user
+# override of e.g. the "page" fixture, some pytest versions drop "browser_name"
+# from the fixture closure, which would silently disable running the test
+# against multiple browsers.
+# https://github.com/microsoft/playwright-pytest/issues/172
+_BROWSER_FIXTURES = ("page", "context", "new_context", "browser", "browser_type")
+
+
 def pytest_generate_tests(metafunc: Any) -> None:
+    if "browser_name" not in metafunc.fixturenames and any(
+        name in metafunc.fixturenames for name in _BROWSER_FIXTURES
+    ):
+        metafunc.fixturenames.append("browser_name")
     if "browser_name" in metafunc.fixturenames:
         browsers = metafunc.config.option.browser or ["chromium"]
         metafunc.parametrize("browser_name", browsers, scope="session")

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -175,6 +175,31 @@ def test_multiple_browsers(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=3)
 
 
+def test_multiple_browsers_with_overridden_page_fixture(
+    testdir: pytest.Testdir,
+) -> None:
+    # Overriding the "page" fixture must not disable running the test against
+    # each requested browser.
+    # https://github.com/microsoft/playwright-pytest/issues/172
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def page(page):
+            yield page
+
+        def test_a(page):
+            pass
+    """
+    )
+    result = testdir.runpytest(
+        "--collect-only", "-q", "--browser", "chromium", "--browser", "firefox"
+    )
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*test_a*chromium*", "*test_a*firefox*"])
+
+
 def test_browser_context_args(testdir: pytest.Testdir) -> None:
     testdir.makeconftest(
         """

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -209,6 +209,31 @@ def test_multiple_browsers(testdir: pytest.Testdir) -> None:
     result.assert_outcomes(passed=3)
 
 
+def test_multiple_browsers_with_overridden_page_fixture(
+    testdir: pytest.Testdir,
+) -> None:
+    # Overriding the "page" fixture must not disable running the test against
+    # each requested browser.
+    # https://github.com/microsoft/playwright-pytest/issues/172
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def page(page):
+            yield page
+
+        def test_a(page):
+            pass
+    """
+    )
+    result = testdir.runpytest(
+        "--collect-only", "-q", "--browser", "chromium", "--browser", "firefox"
+    )
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*test_a*chromium*", "*test_a*firefox*"])
+
+
 def test_browser_context_args(testdir: pytest.Testdir) -> None:
     testdir.makeconftest(
         """


### PR DESCRIPTION
## Summary
- When a user overrides the `page` fixture (e.g. `def page(page): yield page`), some pytest versions drop `browser_name` from the fixture closure, so `--browser chromium --browser firefox` silently runs the test against only one browser instead of parametrizing it.
- In `pytest_generate_tests`, if `browser_name` is absent but a browser-backed fixture (`page`, `context`, `new_context`, `browser`, `browser_type`) is requested, re-add `browser_name` to `metafunc.fixturenames` before parametrizing. It's a no-op when `browser_name` is already present (pytest 9) or when no browser fixture is used, so non-browser tests are untouched.
- Applied to both the sync and asyncio plugins, with a regression test in each that collects `test_a[chromium]` and `test_a[firefox]` from an overridden `page` fixture.

Reverting the plugin change makes the new tests fail on pytest 8.3.5 (only `test_a` is collected), confirming they guard the regression. On pytest 9 the closure already keeps `browser_name`, so the tests pass there regardless.

Fixes #172