### PR TITLE
devops(pipeline): resolve pip packages from DevDiv_PublicPackages feed

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -34,18 +34,40 @@ extends:
             path: $(Build.ArtifactStagingDirectory)/esrp-build
             artifact: esrp-build
         steps:
+        - bash: |
+            if [[ ! "$CURRENT_BRANCH" =~ ^v[0-9]+\..* ]]; then
+              echo "Can only publish from a release tag (v*)."
+              echo "Unexpected ref name: $CURRENT_BRANCH"
+              exit 1
+            fi
+          env:
+            CURRENT_BRANCH: ${{ variables['Build.SourceBranchName'] }}
+          displayName: 'Check the ref is a release tag'
+          # Allow manual runs on any branch to exercise the build without publishing.
+          condition: ne(variables['Build.Reason'], 'Manual')
         - task: UsePythonVersion@0
           inputs:
             versionSpec: '3.10'
           displayName: 'Use Python'
+        # Resolve every pip install (including the isolated build environments
+        # that `python -m build` creates) through the DevDiv_PublicPackages Azure
+        # Artifacts feed instead of pypi.org, as required by SFI-ES4.2.4. The
+        # task exports an authenticated PIP_INDEX_URL.
+        - task: PipAuthenticate@1
+          inputs:
+            artifactFeeds: DevDiv/DevDiv_PublicPackages
+          displayName: 'Authenticate pip to DevDiv_PublicPackages feed'
         - script: |
-            python -m pip install --upgrade pip
-            pip install -r local-requirements.txt
+            python -m pip install --upgrade pip --disable-pip-version-check
+            pip install -r local-requirements.txt --disable-pip-version-check
             python -m build --outdir $(Build.ArtifactStagingDirectory)/esrp-build pytest-playwright
             python -m build --outdir $(Build.ArtifactStagingDirectory)/esrp-build pytest-playwright-asyncio
           displayName: 'Install & Build'
       - job: Publish
         dependsOn: Build
+        # Only publish from release tags; manual runs on a branch stop after Build,
+        # which lets the build be exercised without publishing.
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
         templateContext:
           type: releaseJob
           isProduction: true


### PR DESCRIPTION
## Summary
- Run `PipAuthenticate@1` against the `DevDiv_PublicPackages` feed before any pip use, so the release build no longer contacts pypi.org or files.pythonhosted.org (SFI-ES4.2.4).
- Manual runs skip the release tag check and stop after `Build`; `Publish` only runs for `refs/tags/v*`.